### PR TITLE
Corrections for Addtion of Device Types for OCF Amsterdam.

### DIFF
--- a/oic.devicemap-content.json
+++ b/oic.devicemap-content.json
@@ -33,7 +33,7 @@
     "devicename": "Battery",
     "devicetype": "oic.d.battery",
     "resources": [
-      {"resourcetypetitle": "Battery", "resourcetypeid": "oic.r.battery"}
+      {"resourcetypetitle": "Battery", "resourcetypeid": "oic.r.energy.battery"}
     ]
   },
   {
@@ -126,8 +126,8 @@
     "resources": [
       {"resourcetypetitle":"Binary Switch", "resourcetypeid": "oic.r.switch.binary"},
       {"resourcetypetitle": "Operational State", "resourcetypeid": "oic.r.operational.state"},
-      {"resourcetypetitle": "Battery", "resourcetypeid": "oic.r.battery"},
-      {"resourcetypetitle": "Vehicle Connector", "resourcetypeid": "oic.r.vehicleconnector"}
+      {"resourcetypetitle": "Battery", "resourcetypeid": "oic.r.energy.battery"},
+      {"resourcetypetitle": "Vehicle Connector", "resourcetypeid": "oic.r.vehicle.connector"}
     ]
   },
   {


### PR DESCRIPTION
Corrections in 53c90989e8d3e7b85784bd11a175005f84cba71e:
- Corrected "resourcetypeid" for Battery resource in Battery device
- Corrected "resourcetypeid" for Battery and Vehicle Connector resources in Electric Vehicle Charger device