### PR TITLE
Add oic.d.virtual device type.

### DIFF
--- a/oic.devicemap-content.json
+++ b/oic.devicemap-content.json
@@ -319,6 +319,13 @@
      ]
    },
    {
+     "devicename": "Virtual Device",
+     "devicetype": "oic.d.virtual",
+     "resources": [
+       {"resourcetypetitle": "Device", "resourcetypeid": "oic.wk.d"}
+     ]
+   },
+   {
      "devicename": "Washer (Laundry)",
      "devicetype": "oic.d.washer",
      "resources": [


### PR DESCRIPTION
This device type is specified in the OCF Bridging specification.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>