### PR TITLE
Remove oic.wk.d from oic.d.virtual

### DIFF
--- a/oic.devicemap-content.json
+++ b/oic.devicemap-content.json
@@ -322,7 +322,6 @@
      "devicename": "Virtual Device",
      "devicetype": "oic.d.virtual",
      "resources": [
-       {"resourcetypetitle": "Device", "resourcetypeid": "oic.wk.d"}
      ]
    },
    {


### PR DESCRIPTION
All devices shall contain oic.wk.d resource. Device map shall only list resources which are Vertical.